### PR TITLE
docker: update image to Ubuntu Noble LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic-20190612
+FROM ubuntu:noble-20241015
 MAINTAINER Lionel Nicolas <lionel.nicolas@nividic.org>
 
 ADD build-image /tmp/build-image

--- a/README.md
+++ b/README.md
@@ -17,10 +17,13 @@ It's based on:
 docker run \
 	-it \
 	--publish 18080:18080 \
+	--ulimit nofile=65535:65535 \
 	--volume /mnt/persistent-storage/data:/var/cache/squid \
 	--volume /var/log/vmc-cacher:/var/log/squid \
 	lionelnicolas/package-manager-cache
 ```
+
+N.B. The ulimit option may be dropped if file descriptor exhaustion is not an issue on a given system.
 
 ### Configuring APT
 

--- a/build-image
+++ b/build-image
@@ -18,9 +18,9 @@ export DEBIAN_FRONTEND=noninteractive
 
 # configure apt sources
 cat >/etc/apt/sources.list <<EOF
-deb http://archive.ubuntu.com/ubuntu/ bionic          main restricted universe
-deb http://archive.ubuntu.com/ubuntu/ bionic-updates  main restricted universe
-deb http://archive.ubuntu.com/ubuntu/ bionic-security main restricted universe
+deb http://archive.ubuntu.com/ubuntu/ noble          main restricted universe
+deb http://archive.ubuntu.com/ubuntu/ noble-updates  main restricted universe
+deb http://archive.ubuntu.com/ubuntu/ noble-security main restricted universe
 EOF
 
 # update package list

--- a/storeid-wrapper
+++ b/storeid-wrapper
@@ -8,13 +8,13 @@ __version__   = "1.2"
 import re
 import sys
 
-HTTPREDIR     = re.compile('^http://httpredir\.debian\.org/.*')
+HTTPREDIR     = re.compile(r'^http://httpredir\.debian\\.org/.*')
 
 APT_DOMAIN    = 'http://apt.squid.internal'
-APT_RE_MIRROR = re.compile('^.*/(debian|ubuntu)/(pool/.*)\.(deb|udeb|tar.gz|tar.xz|tar.bz2)$')
+APT_RE_MIRROR = re.compile(r'^.*/(debian|ubuntu)/(pool/.*)\.(deb|udeb|tar.gz|tar.xz|tar.bz2)$')
 
 YUM_DOMAIN    = 'http://yum.squid.internal'
-YUM_RE_MIRROR = re.compile('^.*/(x86_64/.*)\.(gz|bz2|xml|srpm|drpm|rpm)$')
+YUM_RE_MIRROR = re.compile(r'^.*/(x86_64/.*)\.(gz|bz2|xml|srpm|drpm|rpm)$')
 
 while True:
     try:


### PR DESCRIPTION
This also documents a workaround (for a crash that was also happening with the bionic version) wherby adding `--ulimit nofile=65535:65535` to the docker run invocation prevents the container from going down, see e.g. https://gitlab.alpinelinux.org/alpine/aports/-/issues/15091